### PR TITLE
Improve coverage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,14 @@ mod tests {
 
         assert_eq!(result, r#"<div>Hi</div>"#);
     }
+
+    #[test]
+    fn it_works_with_string_refs() {
+        let string_ref = &"Hi".to_string();
+        let result = html! { <div>{string_ref}</div> }.to_string();
+
+        assert_eq!(result, r#"<div>Hi</div>"#);
+    }
 }
 
 pub type Elements = Component;
@@ -416,12 +424,6 @@ impl Render for Component {
 impl Render for String {
     fn render_to_string(&self, buffer: &mut String) {
         buffer.push_str(&escape(self))
-    }
-}
-
-impl Render for &String {
-    fn render_to_string(&self, buffer: &mut String) {
-        buffer.push_str(&escape(*self))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,30 @@ mod tests {
             r#"<div class="flex gap-4"><div class="flex flex-col gap-4"><div>1</div><div>2</div></div></div>"#
         );
     }
+
+    #[test]
+    fn it_works_with_floats() {
+        let x = 3.14;
+        let result = html! { <div>{x}</div> }.to_string();
+
+        assert_eq!(result, r#"<div>3.14</div>"#);
+    }
+
+    #[test]
+    fn it_works_with_special_characters() {
+        let special_characters = "<>&\"'";
+        let result = html! { <div>{special_characters}</div> }.to_string();
+
+        assert_eq!(result, r#"<div>&lt;&gt;&amp;&quot;&#39;</div>"#);
+    }
+
+    #[test]
+    fn it_works_with_strings() {
+        let string = "Hi".to_string();
+        let result = html! { <div>{string}</div> }.to_string();
+
+        assert_eq!(result, r#"<div>Hi</div>"#);
+    }
 }
 
 pub type Elements = Component;


### PR DESCRIPTION
Awesome library!

This PR increases coverage from 75% to 100%, by adding tests and removing an extra* fn.

*In my testing, The `&String`'s `render_to_string` fn never executes, and Rust executes the `String`'s fn instead. Would this make sense, or did I miss something?

Thanks for taking a look!